### PR TITLE
fix(security): detect Unicode homoglyph injection in prompt guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+- **Homoglyph detection in prompt injection checks** (CWE-176 / OWASP LLM01):
+  Guardrails engine now applies NFKC normalization + Cyrillic-to-Latin confusable
+  mapping (~26 pairs) before pattern matching, preventing Unicode homoglyph bypass
+  of prompt-injection detection. Dep: `unicode-normalization`. Closes #7.
+
 ---
 
 ## [1.1.0] - 2026-04-12

--- a/crates/argentor-agent/Cargo.toml
+++ b/crates/argentor-agent/Cargo.toml
@@ -33,6 +33,8 @@ tokio-stream = "0.1"
 toml.workspace = true
 regex.workspace = true
 base64 = "0.22"
+unicode-normalization = "0.1"
+parking_lot.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/argentor-agent/src/guardrails.rs
+++ b/crates/argentor-agent/src/guardrails.rs
@@ -45,6 +45,7 @@
 use regex::Regex;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
+use unicode_normalization::UnicodeNormalization;
 
 // ---------------------------------------------------------------------------
 // Core types
@@ -577,11 +578,35 @@ fn prompt_injection_patterns() -> Vec<&'static str> {
     ]
 }
 
+/// Normalize homoglyphs by applying NFKC normalization and mapping Cyrillic confusables to Latin
+fn normalize_homoglyphs(text: &str) -> String {
+    let normalized: String = text.nfkc().collect();
+
+    let cyrillic_map = [
+        ('а', 'a'), ('е', 'e'), ('о', 'o'), ('р', 'p'), ('с', 'c'), ('у', 'y'),
+        ('і', 'i'), ('ј', 'j'), ('ѕ', 's'), ('һ', 'h'), ('ԁ', 'd'), ('ԝ', 'w'),
+        ('А', 'A'), ('В', 'B'), ('С', 'C'), ('Е', 'E'), ('Н', 'H'), ('І', 'I'),
+        ('К', 'K'), ('М', 'M'), ('О', 'O'), ('Р', 'P'), ('Ѕ', 'S'), ('Т', 'T'),
+        ('У', 'Y'), ('Х', 'X'),
+    ];
+
+    let mut result = String::new();
+    for ch in normalized.chars() {
+        if let Some((_, latin)) = cyrillic_map.iter().find(|(cyrillic, _)| *cyrillic == ch) {
+            result.push(*latin);
+        } else {
+            result.push(ch);
+        }
+    }
+    result
+}
+
 fn check_prompt_injection(rule: &GuardrailRule, text: &str) -> Vec<Violation> {
     let lower = text.to_lowercase();
+    let normalized = normalize_homoglyphs(&lower);
     let mut vs = Vec::new();
     for pattern in prompt_injection_patterns() {
-        if let Some(pos) = lower.find(pattern) {
+        if let Some(pos) = normalized.find(pattern) {
             vs.push(Violation {
                 rule_name: rule.name.clone(),
                 severity: rule.severity.clone(),

--- a/crates/argentor-agent/tests/security_regression_injection.rs
+++ b/crates/argentor-agent/tests/security_regression_injection.rs
@@ -113,7 +113,6 @@ fn test_blocks_base64_encoded_injection() {
 /// KNOWN GAP: current matching is case-folded ASCII; homoglyphs slip through.
 /// Tracked separately so we know this attack vector is unguarded.
 #[test]
-#[ignore = "SECURITY-TODO: homoglyph normalization not implemented — documented limitation"]
 fn test_blocks_unicode_homoglyph_injection() {
     let engine = GuardrailEngine::new();
     // 'i' in "ignore" replaced with Cyrillic 'і' (U+0456)


### PR DESCRIPTION
## Summary

- Add `normalize_homoglyphs()` with NFKC normalization + custom Cyrillic→Latin confusable map (~26 pairs) applied **before** pattern matching in `check_prompt_injection()`
- Prevents Unicode homoglyph bypass of prompt-injection detection (CWE-176 / OWASP LLM01)
- Lightweight custom map chosen over `unicode-security` crate to minimize dependency footprint
- New dep: `unicode-normalization 0.1` (in `argentor-agent`)

## Test plan

- [x] `test_blocks_unicode_homoglyph_injection` enabled (was `#[ignore]`)
- [ ] `cargo test -p argentor-agent` passes
- [ ] `cargo clippy --workspace` clean

Closes #7