### PR TITLE
refactor: SkillRegistry interior mutability with parking_lot::RwLock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **SkillRegistry interior mutability refactor**: `register()` and related methods
+  now accept `&self` via internal `parking_lot::RwLock`. Updated all call sites
+  across builtins, CLI, MCP manager, plugin loader, examples, and tests.
+  Closes #13.
+
 ---
 
 ## [1.1.0] - 2026-04-12

--- a/crates/argentor-agent/src/runner.rs
+++ b/crates/argentor-agent/src/runner.rs
@@ -41,8 +41,8 @@ type OptionalProxy = Option<(Arc<argentor_mcp::McpProxy>, String)>;
 /// use std::sync::Arc;
 /// use std::path::PathBuf;
 ///
-/// let mut registry = SkillRegistry::new();
-/// register_builtins(&mut registry);
+/// let registry = SkillRegistry::new();
+/// register_builtins(&registry);
 /// let skills = Arc::new(registry);
 /// let permissions = PermissionSet::new();
 /// let audit = Arc::new(AuditLog::new(PathBuf::from("/tmp/audit")));

--- a/crates/argentor-agent/tests/llm_integration.rs
+++ b/crates/argentor-agent/tests/llm_integration.rs
@@ -557,8 +557,8 @@ async fn mock_tool_calling_full_loop() {
 
     let config = mock_config(LlmProvider::Claude, &server.uri());
 
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let skills = Arc::new(registry);
     let permissions = PermissionSet::new();
     let tmp = tempfile::tempdir().unwrap();
@@ -1325,8 +1325,8 @@ async fn test_agent_runner_real_e2e() {
     let config = make_config(LlmProvider::Claude, "claude-haiku-4-5-20251001", api_key);
 
     // Set up a skill registry with builtins (echo, time, etc.)
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let skills = Arc::new(registry);
 
     let permissions = PermissionSet::new();

--- a/crates/argentor-agent/tests/regression.rs
+++ b/crates/argentor-agent/tests/regression.rs
@@ -293,8 +293,8 @@ async fn test_agent_runner_construction() {
 async fn test_agent_runner_with_builtins() {
     let tmp = tempfile::tempdir().unwrap();
     let audit = Arc::new(AuditLog::new(tmp.path().join("audit")));
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
 
     // Verify all 44 builtins registered (9 core + 29 utility + 6 document loaders)
     assert_eq!(registry.skill_count(), 44);

--- a/crates/argentor-agent/tests/regression_e2e.rs
+++ b/crates/argentor-agent/tests/regression_e2e.rs
@@ -68,8 +68,8 @@ fn claude_text(text: &str) -> serde_json::Value {
 fn build_agent(url: &str) -> AgentRunner {
     let tmp = tempfile::tempdir().unwrap();
     let audit = Arc::new(AuditLog::new(tmp.path().join("audit")));
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let skills = Arc::new(registry);
     let permissions = PermissionSet::new();
     AgentRunner::new(make_config(url.to_string()), skills, permissions, audit)
@@ -159,8 +159,8 @@ impl LlmBackend for ScriptedBackend {
 fn build_scripted_agent(backend: ScriptedBackend) -> AgentRunner {
     let tmp = tempfile::tempdir().unwrap();
     let audit = Arc::new(AuditLog::new(tmp.path().join("audit")));
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let skills = Arc::new(registry);
     let permissions = PermissionSet::new();
     AgentRunner::from_backend(Box::new(backend), skills, permissions, audit, 10)
@@ -584,8 +584,8 @@ async fn test_full_loop_tool_discovery_filters_tools() {
 
     let tmp = tempfile::tempdir().unwrap();
     let audit = Arc::new(AuditLog::new(tmp.path().join("audit")));
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let total_tools = registry.skill_count();
     assert!(
         total_tools >= 30,

--- a/crates/argentor-agent/tests/regression_error_recovery.rs
+++ b/crates/argentor-agent/tests/regression_error_recovery.rs
@@ -139,8 +139,8 @@ impl LlmBackend for ScriptedBackend {
 fn build_scripted_agent(backend: ScriptedBackend, max_turns: u32) -> AgentRunner {
     let tmp = tempfile::tempdir().unwrap();
     let audit = Arc::new(AuditLog::new(tmp.path().join("audit")));
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let skills = Arc::new(registry);
     let permissions = PermissionSet::new();
     AgentRunner::from_backend(Box::new(backend), skills, permissions, audit, max_turns)

--- a/crates/argentor-builtins/src/lib.rs
+++ b/crates/argentor-builtins/src/lib.rs
@@ -209,7 +209,7 @@ use std::sync::Arc;
 /// **Web & Network:** web_search, web_scraper, rss_reader, dns_lookup, ip_tools
 /// **Security & AI:** prompt_guard, secret_scanner, diff_tool, summarizer
 /// **Observability:** metrics_collector, color_converter
-pub fn register_utility_skills(registry: &mut SkillRegistry) {
+pub fn register_utility_skills(registry: &SkillRegistry) {
     // Data & Text
     registry.register(Arc::new(CalculatorSkill::default()));
     registry.register(Arc::new(TextTransformSkill::default()));
@@ -257,7 +257,7 @@ pub fn register_utility_skills(registry: &mut SkillRegistry) {
 /// Register all built-in skills into the given registry.
 /// Uses the provided vector store and embedding provider for memory skills.
 pub fn register_builtins_with_memory(
-    registry: &mut SkillRegistry,
+    registry: &SkillRegistry,
     store: Arc<dyn VectorStore>,
     embedder: Arc<dyn EmbeddingProvider>,
 ) {
@@ -279,7 +279,7 @@ pub fn register_builtins_with_memory(
 }
 
 /// Register built-in skills without memory (backwards compatible).
-pub fn register_builtins(registry: &mut SkillRegistry) {
+pub fn register_builtins(registry: &SkillRegistry) {
     registry.register(Arc::new(ShellSkill::new()));
     registry.register(Arc::new(FileReadSkill::new()));
     registry.register(Arc::new(FileWriteSkill::new()));
@@ -294,7 +294,7 @@ pub fn register_builtins(registry: &mut SkillRegistry) {
 
 /// Register built-in skills with a custom approval channel for HITL.
 pub fn register_builtins_with_approval(
-    registry: &mut SkillRegistry,
+    registry: &SkillRegistry,
     approval_channel: Arc<dyn ApprovalChannel>,
 ) {
     registry.register(Arc::new(ShellSkill::new()));
@@ -311,7 +311,7 @@ pub fn register_builtins_with_approval(
 
 /// Register all built-in skills including memory and a custom approval channel.
 pub fn register_all(
-    registry: &mut SkillRegistry,
+    registry: &SkillRegistry,
     store: Arc<dyn VectorStore>,
     embedder: Arc<dyn EmbeddingProvider>,
     approval_channel: Arc<dyn ApprovalChannel>,
@@ -336,7 +336,7 @@ pub fn register_all(
 /// Register orchestration-specific skills (artifact_store, agent_delegate, task_status).
 /// These require a TaskQueueHandle and ArtifactBackend from the orchestrator.
 pub fn register_orchestration_builtins(
-    registry: &mut SkillRegistry,
+    registry: &SkillRegistry,
     queue: Arc<dyn TaskQueueHandle>,
     artifact_backend: Arc<dyn ArtifactBackend>,
 ) {
@@ -351,7 +351,7 @@ pub fn register_orchestration_builtins(
 /// configured with the given `BrowserConfig`. The actual WebDriver connection
 /// is established lazily when the skill is first invoked, and only when the
 /// `browser` feature is enabled.
-pub fn register_builtins_with_browser(registry: &mut SkillRegistry, config: BrowserConfig) {
+pub fn register_builtins_with_browser(registry: &SkillRegistry, config: BrowserConfig) {
     registry.register(Arc::new(ShellSkill::new()));
     registry.register(Arc::new(FileReadSkill::new()));
     registry.register(Arc::new(FileWriteSkill::new()));

--- a/crates/argentor-builtins/src/xcapitsff_skills.rs
+++ b/crates/argentor-builtins/src/xcapitsff_skills.rs
@@ -945,8 +945,8 @@ mod tests {
 
     #[test]
     fn test_register_xcapitsff_skills_registers_all_five() {
-        let mut registry = SkillRegistry::new();
-        register_xcapitsff_skills(&mut registry, "http://test-backend:8000");
+        let registry = SkillRegistry::new();
+        register_xcapitsff_skills(&registry, "http://test-backend:8000");
         assert!(registry.get("xcapitsff_search").is_some());
         assert!(registry.get("xcapitsff_lead_info").is_some());
         assert!(registry.get("xcapitsff_ticket_info").is_some());

--- a/crates/argentor-builtins/tests/builtins_integration.rs
+++ b/crates/argentor-builtins/tests/builtins_integration.rs
@@ -19,16 +19,16 @@ use std::sync::Arc;
 
 #[test]
 fn register_builtins_registers_expected_count() {
-    let mut registry = SkillRegistry::new();
-    register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    register_builtins(&registry);
     // register_builtins adds: 9 core + 29 utility + 6 document loaders = 44
     assert_eq!(registry.skill_count(), 44);
 }
 
 #[test]
 fn register_builtins_contains_expected_skill_names() {
-    let mut registry = SkillRegistry::new();
-    register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    register_builtins(&registry);
 
     let core_skills = [
         "shell",
@@ -70,10 +70,10 @@ fn register_builtins_contains_expected_skill_names() {
 
 #[test]
 fn register_builtins_with_memory_registers_all_skills() {
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     let store: Arc<dyn VectorStore> = Arc::new(InMemoryVectorStore::new());
     let embedder: Arc<dyn EmbeddingProvider> = Arc::new(LocalEmbedding::default());
-    register_builtins_with_memory(&mut registry, store, embedder);
+    register_builtins_with_memory(&registry, store, embedder);
     // 9 core + 29 utility + 6 document loaders + memory_store + memory_search = 46
     assert_eq!(registry.skill_count(), 46);
     assert!(registry.get("memory_store").is_some());

--- a/crates/argentor-cli/examples/demo_automation.rs
+++ b/crates/argentor-cli/examples/demo_automation.rs
@@ -386,8 +386,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // 3. Set up SkillRegistry with memory
     let store: Arc<dyn VectorStore> = Arc::new(InMemoryVectorStore::new());
     let embedder = Arc::new(LocalEmbedding::default());
-    let mut registry = SkillRegistry::new();
-    register_builtins_with_memory(&mut registry, store, embedder);
+    let registry = SkillRegistry::new();
+    register_builtins_with_memory(&registry, store, embedder);
 
     // 4. Set up permissions
     let mut permissions = PermissionSet::new();

--- a/crates/argentor-cli/examples/demo_pipeline.rs
+++ b/crates/argentor-cli/examples/demo_pipeline.rs
@@ -467,8 +467,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let store: Arc<dyn VectorStore> = Arc::new(InMemoryVectorStore::new());
     let embedder = Arc::new(LocalEmbedding::default());
-    let mut registry = SkillRegistry::new();
-    register_builtins_with_memory(&mut registry, store, embedder);
+    let registry = SkillRegistry::new();
+    register_builtins_with_memory(&registry, store, embedder);
 
     let mut permissions = PermissionSet::new();
     permissions.grant(Capability::ShellExec {

--- a/crates/argentor-cli/examples/demo_security_challenge.rs
+++ b/crates/argentor-cli/examples/demo_security_challenge.rs
@@ -268,8 +268,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let audit_dir = temp_dir.join("audit");
 
     // Build components
-    let mut registry = SkillRegistry::new();
-    register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    register_builtins(&registry);
 
     // Set up RESTRICTIVE permissions — only what's needed for legitimate work
     let mut permissions = PermissionSet::new();

--- a/crates/argentor-cli/examples/demo_skills_toolkit.rs
+++ b/crates/argentor-cli/examples/demo_skills_toolkit.rs
@@ -199,8 +199,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt().with_env_filter("warn").init();
 
     // ── Setup ──────────────────────────────────────────────────
-    let mut registry = SkillRegistry::new();
-    register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    register_builtins(&registry);
 
     let mut permissions = PermissionSet::new();
     permissions.grant(Capability::NetworkAccess {

--- a/crates/argentor-cli/examples/demo_team.rs
+++ b/crates/argentor-cli/examples/demo_team.rs
@@ -966,8 +966,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let audit_dir = temp_dir.join("audit");
 
     // ── Setup infrastructure ────────────────────────────────────
-    let mut registry = SkillRegistry::new();
-    register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    register_builtins(&registry);
 
     let mut permissions = PermissionSet::new();
     permissions.grant(Capability::ShellExec {

--- a/crates/argentor-cli/src/main.rs
+++ b/crates/argentor-cli/src/main.rs
@@ -262,7 +262,7 @@ fn expand_env_vars(input: &str) -> String {
 async fn load_markdown_skills(
     config: &ArgentorConfig,
     config_dir: &std::path::Path,
-    registry: &mut SkillRegistry,
+    registry: &SkillRegistry,
 ) -> String {
     let dir = match &config.markdown_skills_dir {
         Some(d) => {
@@ -299,7 +299,7 @@ async fn load_markdown_skills(
 }
 
 /// Register custom tool groups from config.
-fn load_tool_groups(config: &ArgentorConfig, registry: &mut SkillRegistry) {
+fn load_tool_groups(config: &ArgentorConfig, registry: &SkillRegistry) {
     if !config.tool_groups.is_empty() {
         registry.register_groups(config.tool_groups.clone());
         info!(
@@ -501,25 +501,25 @@ async fn main() -> anyhow::Result<()> {
             info!("Vector memory initialized");
 
             // Load skills: builtins (with memory) first, then WASM skills from config
-            let mut registry = SkillRegistry::new();
-            argentor_builtins::register_builtins_with_memory(&mut registry, vector_store, embedder);
+            let registry = SkillRegistry::new();
+            argentor_builtins::register_builtins_with_memory(&registry, vector_store, embedder);
             info!(count = registry.skill_count(), "Built-in skills registered");
 
             if !config.skills.is_empty() {
                 let loader = SkillLoader::new()?;
-                let loaded = loader.load_all(&config.skills, &config_dir, &mut registry)?;
+                let loaded = loader.load_all(&config.skills, &config_dir, &registry)?;
                 info!(count = loaded, "WASM skills loaded from config");
             }
 
             // Load markdown skills and tool groups
-            let _prompt_injection = load_markdown_skills(&config, &config_dir, &mut registry).await;
-            load_tool_groups(&config, &mut registry);
+            let _prompt_injection = load_markdown_skills(&config, &config_dir, &registry).await;
+            load_tool_groups(&config, &registry);
 
             // Connect to MCP servers and register their tools as skills
             let mcp_manager = Arc::new(argentor_mcp::McpServerManager::new());
             if !config.mcp_servers.is_empty() {
                 let errors = mcp_manager
-                    .connect_all(&config.mcp_servers, &mut registry)
+                    .connect_all(&config.mcp_servers, &registry)
                     .await;
                 if !errors.is_empty() {
                     tracing::warn!(failed = errors.len(), "Some MCP servers failed to connect");
@@ -626,14 +626,14 @@ async fn main() -> anyhow::Result<()> {
         Commands::Skill { action } => match action {
             SkillAction::List => {
                 // Load all skills: builtins + config + markdown
-                let mut registry = SkillRegistry::new();
-                argentor_builtins::register_builtins(&mut registry);
+                let registry = SkillRegistry::new();
+                argentor_builtins::register_builtins(&registry);
                 if !config.skills.is_empty() {
                     let loader = SkillLoader::new()?;
-                    let _ = loader.load_all(&config.skills, &config_dir, &mut registry);
+                    let _ = loader.load_all(&config.skills, &config_dir, &registry);
                 }
-                let _ = load_markdown_skills(&config, &config_dir, &mut registry).await;
-                load_tool_groups(&config, &mut registry);
+                let _ = load_markdown_skills(&config, &config_dir, &registry).await;
+                load_tool_groups(&config, &registry);
 
                 let skills = registry.list_descriptors();
                 if skills.is_empty() {
@@ -700,25 +700,25 @@ async fn main() -> anyhow::Result<()> {
             let audit = Arc::new(AuditLog::new(config.data_dir.join("audit")));
 
             // Load skills: builtins + config + markdown
-            let mut registry = SkillRegistry::new();
+            let registry = SkillRegistry::new();
             if interactive_approval {
                 let channel = Arc::new(argentor_builtins::StdinApprovalChannel::new(
                     std::time::Duration::from_secs(approval_timeout),
                 ));
-                argentor_builtins::register_builtins_with_approval(&mut registry, channel);
+                argentor_builtins::register_builtins_with_approval(&registry, channel);
                 info!(
                     "Interactive approval enabled (timeout: {}s)",
                     approval_timeout
                 );
             } else {
-                argentor_builtins::register_builtins(&mut registry);
+                argentor_builtins::register_builtins(&registry);
             }
             if !config.skills.is_empty() {
                 let loader = SkillLoader::new()?;
-                let _ = loader.load_all(&config.skills, &config_dir, &mut registry);
+                let _ = loader.load_all(&config.skills, &config_dir, &registry);
             }
-            let _prompt_injection = load_markdown_skills(&config, &config_dir, &mut registry).await;
-            load_tool_groups(&config, &mut registry);
+            let _prompt_injection = load_markdown_skills(&config, &config_dir, &registry).await;
+            load_tool_groups(&config, &registry);
 
             // Build permissions
             let mut permissions = PermissionSet::new();

--- a/crates/argentor-gateway/tests/regression.rs
+++ b/crates/argentor-gateway/tests/regression.rs
@@ -37,8 +37,8 @@ async fn start_full_server(api_keys: Vec<String>) -> (String, tempfile::TempDir)
     );
 
     // Register all builtins
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
 
     // Build permissions from builtins
     let mut permissions = PermissionSet::new();

--- a/crates/argentor-gateway/tests/regression_api.rs
+++ b/crates/argentor-gateway/tests/regression_api.rs
@@ -86,8 +86,8 @@ async fn start_full_server() -> (
             .unwrap(),
     );
 
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let skills = Arc::new(registry);
     let permissions = PermissionSet::new();
     let agent = Arc::new(AgentRunner::new(

--- a/crates/argentor-mcp/src/discovery.rs
+++ b/crates/argentor-mcp/src/discovery.rs
@@ -99,7 +99,7 @@ mod tests {
     }
 
     fn make_registry() -> SkillRegistry {
-        let mut registry = SkillRegistry::new();
+        let registry = SkillRegistry::new();
         registry.register(Arc::new(DummySkill::new(
             "memory_store",
             "Store text in memory",

--- a/crates/argentor-mcp/src/in_process.rs
+++ b/crates/argentor-mcp/src/in_process.rs
@@ -373,7 +373,7 @@ impl InProcessMcpServer {
     ///
     /// Tool names follow the convention `mcp__{server_name}__{tool_name}`,
     /// matching the naming used by [`McpSkill`](crate::skill::McpSkill).
-    pub fn register_skills(self, registry: &mut SkillRegistry) {
+    pub fn register_skills(self, registry: &SkillRegistry) {
         // Collect tool metadata before moving self into Arc.
         let tool_meta: Vec<(String, String, serde_json::Value)> = self
             .tools
@@ -907,18 +907,18 @@ mod tests {
     #[test]
     fn test_register_skills_adds_to_registry() {
         let server = make_test_server();
-        let mut registry = SkillRegistry::new();
+        let registry = SkillRegistry::new();
         assert_eq!(registry.skill_count(), 0);
 
-        server.register_skills(&mut registry);
+        server.register_skills(&registry);
         assert_eq!(registry.skill_count(), 2);
     }
 
     #[test]
     fn test_registered_skill_names_follow_convention() {
         let server = make_test_server();
-        let mut registry = SkillRegistry::new();
-        server.register_skills(&mut registry);
+        let registry = SkillRegistry::new();
+        server.register_skills(&registry);
 
         // Names should be mcp__{server_name}_{tool_name}
         assert!(registry.get("mcp__test_server_greet").is_some());
@@ -928,8 +928,8 @@ mod tests {
     #[test]
     fn test_registered_skill_descriptors() {
         let server = make_test_server();
-        let mut registry = SkillRegistry::new();
-        server.register_skills(&mut registry);
+        let registry = SkillRegistry::new();
+        server.register_skills(&registry);
 
         let skill = registry.get("mcp__test_server_greet").unwrap();
         let desc = skill.descriptor();
@@ -943,8 +943,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_registered_skill_via_registry() {
         let server = make_test_server();
-        let mut registry = SkillRegistry::new();
-        server.register_skills(&mut registry);
+        let registry = SkillRegistry::new();
+        server.register_skills(&registry);
 
         let perms = PermissionSet::new();
         let call = ToolCall {
@@ -961,8 +961,8 @@ mod tests {
     #[tokio::test]
     async fn test_execute_registered_async_skill_via_registry() {
         let server = make_async_server();
-        let mut registry = SkillRegistry::new();
-        server.register_skills(&mut registry);
+        let registry = SkillRegistry::new();
+        server.register_skills(&registry);
 
         let perms = PermissionSet::new();
         let call = ToolCall {
@@ -985,8 +985,8 @@ mod tests {
             |_| Err(ArgentorError::Skill("intentional failure".to_string())),
         );
 
-        let mut registry = SkillRegistry::new();
-        server.register_skills(&mut registry);
+        let registry = SkillRegistry::new();
+        server.register_skills(&registry);
 
         let perms = PermissionSet::new();
         let call = ToolCall {
@@ -1038,8 +1038,8 @@ mod tests {
             |_| Ok("ok".into()),
         );
 
-        let mut registry = SkillRegistry::new();
-        server.register_skills(&mut registry);
+        let registry = SkillRegistry::new();
+        server.register_skills(&registry);
 
         // Dashes and dots should be replaced with underscores
         assert!(registry.get("mcp__my_special_server_tool_with_dashes").is_some());

--- a/crates/argentor-mcp/src/manager.rs
+++ b/crates/argentor-mcp/src/manager.rs
@@ -82,7 +82,7 @@ impl McpServerManager {
     pub async fn connect_all(
         &self,
         configs: &[McpServerConfig],
-        registry: &mut SkillRegistry,
+        registry: &SkillRegistry,
     ) -> Vec<ArgentorError> {
         let mut errors = Vec::new();
 
@@ -113,7 +113,7 @@ impl McpServerManager {
     async fn connect_server(
         &self,
         config: &McpServerConfig,
-        registry: &mut SkillRegistry,
+        registry: &SkillRegistry,
     ) -> ArgentorResult<usize> {
         let args: Vec<&str> = config
             .args
@@ -152,7 +152,7 @@ impl McpServerManager {
     fn register_tools(
         tools: &[McpToolDef],
         client: &Arc<McpClient>,
-        registry: &mut SkillRegistry,
+        registry: &SkillRegistry,
     ) -> Vec<String> {
         let mut names = Vec::new();
         for tool in tools {
@@ -382,8 +382,8 @@ mod tests {
             auto_reconnect: false,
             health_check_interval_secs: 0,
         };
-        let mut registry = SkillRegistry::new();
-        let errors = mgr.connect_all(&[config], &mut registry).await;
+        let registry = SkillRegistry::new();
+        let errors = mgr.connect_all(&[config], &registry).await;
         assert_eq!(errors.len(), 1);
         assert_eq!(mgr.server_count().await, 0);
     }

--- a/crates/argentor-mcp/src/server.rs
+++ b/crates/argentor-mcp/src/server.rs
@@ -502,7 +502,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn make_test_server() -> McpServer {
-        let mut registry = SkillRegistry::new();
+        let registry = SkillRegistry::new();
         registry.register(Arc::new(EchoSkill::new()));
         registry.register(Arc::new(RestrictedSkill::new()));
         McpServer::new(

--- a/crates/argentor-mcp/tests/mcp_integration.rs
+++ b/crates/argentor-mcp/tests/mcp_integration.rs
@@ -75,7 +75,7 @@ fn make_call(id: &str, tool: &str) -> ToolCall {
 }
 
 fn make_proxy_with(skills: Vec<Arc<dyn Skill>>) -> McpProxy {
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     for skill in skills {
         registry.register(skill);
     }
@@ -289,7 +289,7 @@ async fn test_proxy_denied_tracking() {
 
 #[tokio::test]
 async fn test_tool_discovery() {
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     registry.register(Arc::new(StubSkill::ok("memory_store")));
     registry.register(Arc::new(StubSkill::ok("memory_search")));
     registry.register(Arc::new(StubSkill::ok("echo")));
@@ -348,8 +348,8 @@ async fn test_server_manager() {
         health_check_interval_secs: 0,
     };
 
-    let mut registry = SkillRegistry::new();
-    let errors = manager.connect_all(&[config], &mut registry).await;
+    let registry = SkillRegistry::new();
+    let errors = manager.connect_all(&[config], &registry).await;
     assert_eq!(errors.len(), 1);
     // Still no servers managed (the failed one is not tracked).
     assert_eq!(manager.server_count().await, 0);
@@ -371,7 +371,7 @@ async fn test_server_manager() {
             health_check_interval_secs: 30,
         },
     ];
-    let errors = manager.connect_all(&configs, &mut registry).await;
+    let errors = manager.connect_all(&configs, &registry).await;
     assert_eq!(errors.len(), 2);
     assert_eq!(manager.server_count().await, 0);
 

--- a/crates/argentor-orchestrator/tests/e2e_orchestration.rs
+++ b/crates/argentor-orchestrator/tests/e2e_orchestration.rs
@@ -326,8 +326,8 @@ async fn test_e2e_monitor_tracking() {
 async fn test_e2e_progressive_disclosure() {
     let tmp = tempfile::tempdir().unwrap();
     let audit = Arc::new(AuditLog::new(tmp.path().join("audit")));
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let total_skills = registry.skill_count();
     let skills = Arc::new(registry);
     let permissions = PermissionSet::new();

--- a/crates/argentor-python/src/lib.rs
+++ b/crates/argentor-python/src/lib.rs
@@ -201,8 +201,8 @@ impl PySkillRegistry {
     /// Create a new registry with all built-in skills registered.
     #[new]
     fn new() -> PyResult<Self> {
-        let mut registry = argentor_skills::SkillRegistry::new();
-        argentor_builtins::register_builtins(&mut registry);
+        let registry = argentor_skills::SkillRegistry::new();
+        argentor_builtins::register_builtins(&registry);
 
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to create tokio runtime: {e}")))?;
@@ -601,8 +601,8 @@ fn version() -> &'static str {
 /// Return a sorted list of all available built-in skill names.
 #[pyfunction]
 fn available_skills() -> Vec<String> {
-    let mut registry = argentor_skills::SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = argentor_skills::SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let mut names: Vec<String> = registry
         .list_descriptors()
         .iter()

--- a/crates/argentor-skills/Cargo.toml
+++ b/crates/argentor-skills/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 argentor-core.workspace = true
 argentor-security.workspace = true
 serde.workspace = true
+parking_lot.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
 wasmtime.workspace = true

--- a/crates/argentor-skills/benches/skills_benchmarks.rs
+++ b/crates/argentor-skills/benches/skills_benchmarks.rs
@@ -37,7 +37,7 @@ impl Skill for BenchSkill {
 }
 
 fn bench_registry_lookup(c: &mut Criterion) {
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     for i in 0..100 {
         registry.register(Arc::new(BenchSkill::new(&format!("skill_{i}"))));
     }
@@ -63,7 +63,7 @@ fn bench_registry_lookup(c: &mut Criterion) {
 fn bench_registry_register(c: &mut Criterion) {
     c.bench_function("register 100 skills", |b| {
         b.iter(|| {
-            let mut registry = SkillRegistry::new();
+            let registry = SkillRegistry::new();
             for i in 0..100 {
                 registry.register(Arc::new(BenchSkill::new(&format!("skill_{i}"))));
             }
@@ -176,7 +176,7 @@ fn bench_registry_lookup_10(c: &mut Criterion) {
         "artifact_store",
     ];
 
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     for name in &skill_names {
         registry.register(Arc::new(BenchSkill::new(name)));
     }
@@ -220,7 +220,7 @@ fn bench_tool_group_filtering(c: &mut Criterion) {
         "artifact_store",
     ];
 
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     for name in &skill_names {
         registry.register(Arc::new(BenchSkill::new(name)));
     }

--- a/crates/argentor-skills/src/loader.rs
+++ b/crates/argentor-skills/src/loader.rs
@@ -124,7 +124,7 @@ impl SkillLoader {
         &self,
         configs: &[SkillConfig],
         base_dir: &Path,
-        registry: &mut SkillRegistry,
+        registry: &SkillRegistry,
     ) -> ArgentorResult<usize> {
         let mut loaded = 0;
 
@@ -148,7 +148,7 @@ impl SkillLoader {
         &self,
         config: &SkillConfig,
         base_dir: &Path,
-        registry: &mut SkillRegistry,
+        registry: &SkillRegistry,
     ) -> ArgentorResult<()> {
         match config.skill_type {
             SkillType::Wasm => {

--- a/crates/argentor-skills/src/plugin.rs
+++ b/crates/argentor-skills/src/plugin.rs
@@ -71,7 +71,7 @@ pub trait Plugin: Send + Sync {
     fn manifest(&self) -> &PluginManifest;
 
     /// Called when the plugin is loaded. Use this to register skills.
-    fn on_load(&self, _registry: &mut SkillRegistry) {}
+    fn on_load(&self, _registry: &SkillRegistry) {}
 
     /// Called when the plugin is unloaded. Use this for cleanup.
     fn on_unload(&self) {}
@@ -94,7 +94,7 @@ impl PluginRegistry {
     }
 
     /// Load a plugin: calls `on_load` to let it register skills, then stores it.
-    pub fn load(&mut self, plugin: Arc<dyn Plugin>, skill_registry: &mut SkillRegistry) {
+    pub fn load(&mut self, plugin: Arc<dyn Plugin>, skill_registry: &SkillRegistry) {
         plugin.on_load(skill_registry);
         self.plugins.push(plugin);
     }
@@ -169,7 +169,7 @@ mod tests {
             &self.manifest
         }
 
-        fn on_load(&self, _registry: &mut SkillRegistry) {
+        fn on_load(&self, _registry: &SkillRegistry) {
             self.load_called.store(true, Ordering::SeqCst);
         }
 
@@ -207,7 +207,7 @@ mod tests {
             &self.manifest
         }
 
-        fn on_load(&self, registry: &mut SkillRegistry) {
+        fn on_load(&self, registry: &SkillRegistry) {
             registry.register(Arc::new(PluginSkill {
                 descriptor: SkillDescriptor {
                     name: "plugin_skill".to_string(),

--- a/crates/argentor-skills/src/registry.rs
+++ b/crates/argentor-skills/src/registry.rs
@@ -1,6 +1,7 @@
 use crate::skill::{Skill, SkillDescriptor};
 use argentor_core::{ArgentorError, ArgentorResult, ToolCall, ToolResult};
 use argentor_security::PermissionSet;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -179,8 +180,8 @@ pub fn default_tool_groups() -> Vec<ToolGroup> {
 /// assert!(!groups.is_empty()); // default groups are pre-loaded
 /// ```
 pub struct SkillRegistry {
-    skills: HashMap<String, Arc<dyn Skill>>,
-    groups: HashMap<String, ToolGroup>,
+    skills: Arc<RwLock<HashMap<String, Arc<dyn Skill>>>>,
+    groups: Arc<RwLock<HashMap<String, ToolGroup>>>,
 }
 
 impl SkillRegistry {
@@ -192,49 +193,53 @@ impl SkillRegistry {
             .collect();
 
         Self {
-            skills: HashMap::new(),
-            groups,
+            skills: Arc::new(RwLock::new(HashMap::new())),
+            groups: Arc::new(RwLock::new(groups)),
         }
     }
 
     /// Register a skill in the registry.
-    pub fn register(&mut self, skill: Arc<dyn Skill>) {
+    pub fn register(&self, skill: Arc<dyn Skill>) {
         let name = skill.descriptor().name.clone();
         info!(skill = %name, "Registered skill");
-        self.skills.insert(name, skill);
+        self.skills.write().insert(name, skill);
     }
 
     /// Register a custom tool group.
-    pub fn register_group(&mut self, group: ToolGroup) {
+    pub fn register_group(&self, group: ToolGroup) {
         info!(group = %group.name, skills = group.skills.len(), "Registered tool group");
-        self.groups.insert(group.name.clone(), group);
+        self.groups.write().insert(group.name.clone(), group);
     }
 
     /// Register multiple custom tool groups.
-    pub fn register_groups(&mut self, groups: Vec<ToolGroup>) {
+    pub fn register_groups(&self, groups: Vec<ToolGroup>) {
         for group in groups {
             self.register_group(group);
         }
     }
 
     /// Look up a skill by name.
-    pub fn get(&self, name: &str) -> Option<&Arc<dyn Skill>> {
-        self.skills.get(name)
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Skill>> {
+        self.skills.read().get(name).cloned()
     }
 
     /// List descriptors for all registered skills.
-    pub fn list_descriptors(&self) -> Vec<&SkillDescriptor> {
-        self.skills.values().map(|s| s.descriptor()).collect()
+    pub fn list_descriptors(&self) -> Vec<SkillDescriptor> {
+        self.skills
+            .read()
+            .values()
+            .map(|s| s.descriptor().clone())
+            .collect()
     }
 
     /// List all registered tool groups.
-    pub fn list_groups(&self) -> Vec<&ToolGroup> {
-        self.groups.values().collect()
+    pub fn list_groups(&self) -> Vec<ToolGroup> {
+        self.groups.read().values().cloned().collect()
     }
 
     /// Get a tool group by name.
-    pub fn get_group(&self, name: &str) -> Option<&ToolGroup> {
-        self.groups.get(name)
+    pub fn get_group(&self, name: &str) -> Option<ToolGroup> {
+        self.groups.read().get(name).cloned()
     }
 
     /// Execute a tool call, checking permissions first.
@@ -251,7 +256,9 @@ impl SkillRegistry {
     ) -> ArgentorResult<ToolResult> {
         let skill = self
             .skills
+            .read()
             .get(&call.name)
+            .cloned()
             .ok_or_else(|| ArgentorError::Skill(format!("Unknown skill: {}", call.name)))?;
 
         // Check that the permission set has at least one capability of the required type.
@@ -364,13 +371,14 @@ impl SkillRegistry {
 
     /// Return only skills whose names appear in the given list.
     /// Used for progressive tool disclosure in multi-agent orchestration.
-    pub fn filter_by_names(&self, names: &[String]) -> Vec<&SkillDescriptor> {
+    pub fn filter_by_names(&self, names: &[String]) -> Vec<SkillDescriptor> {
         let allowed: std::collections::HashSet<&str> =
             names.iter().map(std::string::String::as_str).collect();
         self.skills
+            .read()
             .values()
             .filter(|s| allowed.contains(s.descriptor().name.as_str()))
-            .map(|s| s.descriptor())
+            .map(|s| s.descriptor().clone())
             .collect()
     }
 
@@ -379,31 +387,33 @@ impl SkillRegistry {
     pub fn filter_to_new(&self, names: &[String]) -> Self {
         let allowed: std::collections::HashSet<&str> =
             names.iter().map(std::string::String::as_str).collect();
-        let skills = self
-            .skills
+        let skills_map = self.skills.read();
+        let skills = skills_map
             .iter()
             .filter(|(name, _)| allowed.contains(name.as_str()))
             .map(|(name, skill)| (name.clone(), skill.clone()))
             .collect();
         Self {
-            skills,
-            groups: self.groups.clone(),
+            skills: Arc::new(RwLock::new(skills)),
+            groups: Arc::clone(&self.groups),
         }
     }
 
     /// Create a new registry containing only skills in the specified tool group.
     /// If the group has an empty skills list (like "full"), returns all skills.
     pub fn filter_by_group(&self, group_name: &str) -> ArgentorResult<Self> {
-        let group = self
-            .groups
+        let groups_read = self.groups.read();
+        let group = groups_read
             .get(group_name)
-            .ok_or_else(|| ArgentorError::Config(format!("Unknown tool group: {group_name}")))?;
+            .ok_or_else(|| ArgentorError::Config(format!("Unknown tool group: {group_name}")))?
+            .clone();
+        drop(groups_read);
 
         if group.skills.is_empty() {
             // "full" group — return everything
             return Ok(Self {
-                skills: self.skills.clone(),
-                groups: self.groups.clone(),
+                skills: Arc::clone(&self.skills),
+                groups: Arc::clone(&self.groups),
             });
         }
 
@@ -413,17 +423,21 @@ impl SkillRegistry {
 
     /// Get skill names that belong to a specific group.
     pub fn skills_in_group(&self, group_name: &str) -> Vec<String> {
-        match self.groups.get(group_name) {
+        let groups_read = self.groups.read();
+        match groups_read.get(group_name) {
             Some(group) if group.skills.is_empty() => {
                 // "full" = all skills
-                self.skills.keys().cloned().collect()
+                drop(groups_read);
+                self.skills.read().keys().cloned().collect()
             }
             Some(group) => {
+                let group_skills = group.skills.clone();
+                drop(groups_read);
+                let skills_read = self.skills.read();
                 // Return only skills that exist in both the group definition and registry
-                group
-                    .skills
+                group_skills
                     .iter()
-                    .filter(|name| self.skills.contains_key(name.as_str()))
+                    .filter(|name| skills_read.contains_key(name.as_str()))
                     .cloned()
                     .collect()
             }
@@ -433,7 +447,7 @@ impl SkillRegistry {
 
     /// Return the total number of registered skills.
     pub fn skill_count(&self) -> usize {
-        self.skills.len()
+        self.skills.read().len()
     }
 }
 
@@ -518,7 +532,7 @@ mod tests {
 
     #[test]
     fn test_filter_by_names_subset() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("echo")));
         reg.register(Arc::new(TestSkill::new("time")));
         reg.register(Arc::new(TestSkill::new("memory_store")));
@@ -530,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_filter_by_names_empty() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("echo")));
 
         let filtered = reg.filter_by_names(&[]);
@@ -539,7 +553,7 @@ mod tests {
 
     #[test]
     fn test_filter_by_names_no_match() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("echo")));
 
         let names = vec!["nonexistent".to_string()];
@@ -549,7 +563,7 @@ mod tests {
 
     #[test]
     fn test_registry_basic_operations() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         assert_eq!(reg.skill_count(), 0);
 
         reg.register(Arc::new(TestSkill::new("echo")));
@@ -560,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_list_descriptors() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("a")));
         reg.register(Arc::new(TestSkill::new("b")));
 
@@ -586,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_filter_by_group_minimal() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("echo")));
         reg.register(Arc::new(TestSkill::new("time")));
         reg.register(Arc::new(TestSkill::new("help")));
@@ -603,7 +617,7 @@ mod tests {
 
     #[test]
     fn test_filter_by_group_full() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("echo")));
         reg.register(Arc::new(TestSkill::new("file_read")));
         reg.register(Arc::new(TestSkill::new("shell")));
@@ -620,7 +634,7 @@ mod tests {
 
     #[test]
     fn test_custom_tool_group() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("my_tool")));
         reg.register(Arc::new(TestSkill::new("other_tool")));
 
@@ -637,7 +651,7 @@ mod tests {
 
     #[test]
     fn test_skills_in_group() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("echo")));
         reg.register(Arc::new(TestSkill::new("time")));
 
@@ -650,7 +664,7 @@ mod tests {
 
     #[test]
     fn test_register_groups_batch() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register_groups(vec![
             ToolGroup::new("a", "Group A", vec!["x".into()]),
             ToolGroup::new("b", "Group B", vec!["y".into()]),
@@ -661,7 +675,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_validate_arguments_denies_returns_error_tool_result() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(DenyingSkill::new("deny_skill")));
 
         let perms = PermissionSet::new();
@@ -681,7 +695,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_validate_arguments_override_works_normally() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("simple_skill")));
 
         let perms = PermissionSet::new();
@@ -698,7 +712,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_capability_type_check_denies_missing_type() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
 
         // Create a skill that requires FileRead capability
         let skill = Arc::new(TestSkill {
@@ -728,7 +742,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_capability_type_check_allows_any_matching_type() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
 
         // Skill requires FileRead with /specific/path
         let skill = Arc::new(TestSkill {
@@ -825,7 +839,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parallel_execution_of_three_independent_tools() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("alpha")));
         reg.register(Arc::new(TestSkill::new("beta")));
         reg.register(Arc::new(TestSkill::new("gamma")));
@@ -862,7 +876,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parallel_one_failure_does_not_affect_others() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(TestSkill::new("good_a")));
         reg.register(Arc::new(FailingSkill::new("bad")));
         reg.register(Arc::new(TestSkill::new("good_b")));
@@ -909,7 +923,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_with_timeout_on_slow_tool() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         reg.register(Arc::new(SlowSkill::new(
             "very_slow",
             std::time::Duration::from_secs(10),
@@ -933,7 +947,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parallel_results_maintain_input_order() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         // Give different delays to each skill so they complete out of order,
         // but results should still be returned in input order.
         reg.register(Arc::new(SlowSkill::new(
@@ -996,7 +1010,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parallel_permission_denial_in_batch() {
-        let mut reg = SkillRegistry::new();
+        let reg = SkillRegistry::new();
         // "open" has no required capabilities
         reg.register(Arc::new(TestSkill::new("open")));
         // "restricted" requires FileRead capability

--- a/crates/argentor-skills/tests/loader_test.rs
+++ b/crates/argentor-skills/tests/loader_test.rs
@@ -47,7 +47,7 @@ fn test_create_skill_loader() {
 fn test_load_valid_wasm_skill_via_loader() {
     let base_dir = assert_prerequisites();
     let loader = SkillLoader::new().expect("failed to create SkillLoader");
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
 
     let config = SkillConfig {
         name: "echo".to_string(),
@@ -64,7 +64,7 @@ fn test_load_valid_wasm_skill_via_loader() {
         capabilities: CapabilityConfig::default(),
     };
 
-    let loaded = loader.load_all(&[config], &base_dir, &mut registry);
+    let loaded = loader.load_all(&[config], &base_dir, &registry);
     assert!(loaded.is_ok(), "load_all should succeed");
     assert_eq!(loaded.unwrap(), 1, "Should have loaded exactly one skill");
     assert_eq!(registry.skill_count(), 1);
@@ -82,7 +82,7 @@ fn test_load_valid_wasm_skill_via_loader() {
 fn test_load_skill_with_nonexistent_path_is_skipped() {
     let base_dir = workspace_root();
     let loader = SkillLoader::new().expect("failed to create SkillLoader");
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
 
     let config = SkillConfig {
         name: "missing-skill".to_string(),
@@ -94,7 +94,7 @@ fn test_load_skill_with_nonexistent_path_is_skipped() {
     };
 
     // load_all should not fail; it skips individual failures and logs a warning
-    let loaded = loader.load_all(&[config], &base_dir, &mut registry);
+    let loaded = loader.load_all(&[config], &base_dir, &registry);
     assert!(
         loaded.is_ok(),
         "load_all should succeed even when a skill fails to load"
@@ -111,7 +111,7 @@ fn test_load_skill_with_nonexistent_path_is_skipped() {
 fn test_load_skill_with_no_path_is_skipped() {
     let base_dir = workspace_root();
     let loader = SkillLoader::new().expect("failed to create SkillLoader");
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
 
     let config = SkillConfig {
         name: "no-path-skill".to_string(),
@@ -122,7 +122,7 @@ fn test_load_skill_with_no_path_is_skipped() {
         capabilities: CapabilityConfig::default(),
     };
 
-    let loaded = loader.load_all(&[config], &base_dir, &mut registry);
+    let loaded = loader.load_all(&[config], &base_dir, &registry);
     assert!(
         loaded.is_ok(),
         "load_all should succeed even when a config is invalid"
@@ -138,7 +138,7 @@ fn test_load_skill_with_no_path_is_skipped() {
 fn test_load_native_skill_type_is_skipped() {
     let base_dir = workspace_root();
     let loader = SkillLoader::new().expect("failed to create SkillLoader");
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
 
     let config = SkillConfig {
         name: "native-skill".to_string(),
@@ -149,7 +149,7 @@ fn test_load_native_skill_type_is_skipped() {
         capabilities: CapabilityConfig::default(),
     };
 
-    let loaded = loader.load_all(&[config], &base_dir, &mut registry);
+    let loaded = loader.load_all(&[config], &base_dir, &registry);
     assert!(
         loaded.is_ok(),
         "load_all should succeed for native skill configs"
@@ -176,7 +176,7 @@ fn test_load_native_skill_type_is_skipped() {
 fn test_load_mix_of_valid_and_invalid_skills() {
     let base_dir = assert_prerequisites();
     let loader = SkillLoader::new().expect("failed to create SkillLoader");
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
 
     let configs = vec![
         SkillConfig {
@@ -230,7 +230,7 @@ fn test_load_mix_of_valid_and_invalid_skills() {
 async fn test_loaded_skill_can_execute() {
     let base_dir = assert_prerequisites();
     let loader = SkillLoader::new().expect("failed to create SkillLoader");
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
 
     let config = SkillConfig {
         name: "echo".to_string(),

--- a/crates/argentor-skills/tests/wasm_integration.rs
+++ b/crates/argentor-skills/tests/wasm_integration.rs
@@ -144,7 +144,7 @@ async fn test_register_and_list_echo_skill() {
         )
         .expect("failed to load echo skill");
 
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     registry.register(Arc::new(skill));
 
     // Verify the skill count
@@ -180,7 +180,7 @@ async fn test_registry_execute_echo_skill() {
         )
         .expect("failed to load echo skill");
 
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     registry.register(Arc::new(skill));
 
     let call = ToolCall {
@@ -247,7 +247,7 @@ async fn test_register_multiple_skills_and_list() {
         )
         .expect("failed to load skill b");
 
-    let mut registry = SkillRegistry::new();
+    let registry = SkillRegistry::new();
     registry.register(Arc::new(skill_a));
     registry.register(Arc::new(skill_b));
 

--- a/experiments/comparison/src/main.rs
+++ b/experiments/comparison/src/main.rs
@@ -59,16 +59,16 @@ async fn scenario_cold_start() -> Vec<Measurement> {
 
     // Warmup
     for _ in 0..WARMUP_ITERATIONS {
-        let mut registry = SkillRegistry::new();
-        argentor_builtins::register_builtins(&mut registry);
+        let registry = SkillRegistry::new();
+        argentor_builtins::register_builtins(&registry);
         std::hint::black_box(&registry);
     }
 
     // Measure
     for _ in 0..SAMPLE_ITERATIONS {
         let start = Instant::now();
-        let mut registry = SkillRegistry::new();
-        argentor_builtins::register_builtins(&mut registry);
+        let registry = SkillRegistry::new();
+        argentor_builtins::register_builtins(&registry);
         let elapsed = start.elapsed();
         std::hint::black_box(&registry);
         samples.push(elapsed);
@@ -83,8 +83,8 @@ async fn scenario_cold_start() -> Vec<Measurement> {
 // ─── Scenario 2: Skill Registry Operations ──────────────────────────────────
 async fn scenario_skill_registry() -> Vec<Measurement> {
     print_header("Scenario 2: Skill Registry Operations");
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
 
     let mut measurements = Vec::new();
 
@@ -122,8 +122,8 @@ async fn scenario_skill_registry() -> Vec<Measurement> {
 // ─── Scenario 3: Tool Dispatch ──────────────────────────────────────────────
 async fn scenario_tool_dispatch() -> Vec<Measurement> {
     print_header("Scenario 3: Tool Dispatch (Calculator skill execution)");
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
 
     let calc = registry.get("calculator").expect("calculator skill registered");
     let input = argentor_core::ToolCall {
@@ -258,8 +258,8 @@ async fn scenario_intelligence_overhead() -> Vec<Measurement> {
 // ─── Scenario 6: Throughput ─────────────────────────────────────────────────
 async fn scenario_throughput() -> Vec<Measurement> {
     print_header("Scenario 6: Throughput (concurrent skill executions)");
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let registry = Arc::new(registry);
 
     const TOTAL_OPS: usize = 10_000;
@@ -316,8 +316,8 @@ async fn scenario_memory_under_load() -> Vec<Measurement> {
     let baseline_kb = memory::current_rss_kb();
 
     // Create 100 sessions with full agent infrastructure
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let registry = Arc::new(registry);
     let _audit = Arc::new(AuditLog::new(std::path::PathBuf::from("/tmp/argentor-bench-audit")));
     let _permissions = PermissionSet::new();
@@ -358,8 +358,8 @@ async fn scenario_memory_under_load() -> Vec<Measurement> {
 async fn scenario_ecosystem_gaps() -> Vec<Measurement> {
     print_header("Scenario 10: Honest Gaps vs Competitors (where we LOSE)");
 
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let argentor_skills = registry.list_descriptors().len();
     let argentor_llm_providers = 19; // Up from 14: added Cohere, Bedrock, Replicate, Fireworks, HuggingFace
     let argentor_vector_stores = 5; // Up from 1: added Pinecone, Weaviate, Qdrant, pgvector
@@ -463,8 +463,8 @@ async fn scenario_mock_llm_loop() -> Vec<Measurement> {
         }
     }
 
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let registry = Arc::new(registry);
     let permissions = PermissionSet::new();
     let audit = Arc::new(AuditLog::new(std::path::PathBuf::from("/tmp/argentor-bench-audit")));
@@ -582,8 +582,8 @@ async fn scenario_multi_turn_loop() -> Vec<Measurement> {
         }
     }
 
-    let mut registry = SkillRegistry::new();
-    argentor_builtins::register_builtins(&mut registry);
+    let registry = SkillRegistry::new();
+    argentor_builtins::register_builtins(&registry);
     let registry = Arc::new(registry);
     let permissions = PermissionSet::new();
     let audit = Arc::new(AuditLog::new(std::path::PathBuf::from(


### PR DESCRIPTION
## Summary

- Internalize `RwLock` inside `SkillRegistry` so `register()`/`unregister()` accept `&self`
- Updated **all** call sites across the workspace:
  - `argentor-builtins`: `register_builtins()`, `register_builtins_with_memory()`, etc.
  - `argentor-cli`: `main.rs` + all 5 examples
  - `argentor-mcp`: `manager.rs`, `in_process.rs`, `discovery.rs`, `server.rs`
  - `argentor-skills`: `loader.rs`, `plugin.rs`
  - `argentor-agent`: `runner.rs` doc examples
  - All test files and benchmarks
  - `experiments/comparison`
- Enables concurrent skill registration without external locking

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace` clean
- [ ] No remaining `&mut registry` in codebase (except doc strings explaining migration)

Closes #13